### PR TITLE
Add progression percentage for bundles compilation

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -12,6 +12,7 @@ return array(
             ),
         ),
         'development_mode'       => true,
+        'progression_mode'       => false,
         //persistent file, some data will be stored there in
         //xml format, need have write access
         'persistent_file'   => './data/minifier/config.xml',

--- a/src/AssetsCompiler/Minifier/Factory.php
+++ b/src/AssetsCompiler/Minifier/Factory.php
@@ -4,7 +4,6 @@ namespace AssetsCompiler\Minifier;
 
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\FactoryInterface;
-use AssetsCompiler\Minifier\Minifier;
 use AssetsCompiler\Minifier\View\Helper\BundlePath;
 
 /**
@@ -102,10 +101,15 @@ class Factory implements FactoryInterface
         list( $jsAdapter, $cssAdapter ) = $this->createAdapters( $options );
         $bundles_options = isset( $options['bundles'] ) ? $options['bundles'] : null;
 
+        $progression_mode = isset( $options['progression_mode'] ) ? true === $options['progression_mode'] : false;
+        $progression = new Progression( $progression_mode );
+
         $minifier = new Minifier( $jsAdapter, $cssAdapter );
         $minifier->setOptions( $bundles_options )
                  ->setPersistentPath( $persistent_path )
-                 ->setPublicDirectory( $public_dir );
+                 ->setPublicDirectory( $public_dir )
+                 ->setProgression( $progression );
+
         return $minifier;
     }
 

--- a/src/AssetsCompiler/Minifier/Progression.php
+++ b/src/AssetsCompiler/Minifier/Progression.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace AssetsCompiler\Minifier;
+
+/**
+ * @author Bastien Moinet
+ */
+class Progression
+{
+    protected $progressionMode;
+
+    public function __construct($progressionMode)
+    {
+        $this->progressionMode = $progressionMode;
+    }
+
+    /**
+     * display the started mode name (js or css)
+     * @param $bundleMode string mode name to output
+     */
+    public function displayBundleStart($bundleMode)
+    {
+        if (false === $this->progressionMode) {
+            return;
+        }
+
+        // output mode name with 5 ending spaces
+        echo str_pad($bundleMode . ':', 5, ' ', STR_PAD_RIGHT) . '  0 %';
+    }
+
+    /**
+     * display the percentage of bundles compilation of a mode
+     * @param string $bundlePercent percentage to output
+     */
+    public function displayBundlePercent($bundlePercent)
+    {
+        if (false === $this->progressionMode) {
+            return;
+        }
+
+        // move 5 characters backward
+        echo "\033[5D";
+
+        // output is always 5 characters long
+        echo str_pad($bundlePercent, 3, ' ', STR_PAD_LEFT) . ' %';
+    }
+
+    /**
+     * display the ending mode line, with a final EOL
+     */
+    public function displayBundleEnd()
+    {
+        if (false === $this->progressionMode) {
+            return;
+        }
+
+        // output only a new line
+        echo "\n";
+    }
+}


### PR DESCRIPTION
Hello,

We use the AssetsCompiler module in one of our project and we appreciate it. Unfortunately, the bundles compilation is very long (many minutes) and it's not easy to know if the process is still running or not, and at which stage it is.

I added then an enhancement to display the percentage of the process of compilation. It is completed optional and disabled by default (see the config key 'progression_mode').
 
![percentage-progression](https://cloud.githubusercontent.com/assets/1481825/23827933/de0cac18-06c0-11e7-8031-9a26fc687ec4.jpg)
